### PR TITLE
homed: add before pam_unix

### DIFF
--- a/templates/system-auth.tpl
+++ b/templates/system-auth.tpl
@@ -4,16 +4,14 @@ auth		sufficient	pam_ssh.so
 {% endif %}
 
 {% if krb5 %}
-auth		[success=3 default=ignore]      pam_krb5.so {{ krb5_params }}
+auth		[success={{ 4 if homed else 3 }} default=ignore]      pam_krb5.so {{ krb5_params }}
 {% endif %}
 
 auth		requisite	pam_faillock.so preauth
 {% if homed %}
-auth		[success=2 default=ignore]	pam_unix.so {{ nullok|default('', true) }} {{ debug|default('', true) }} try_first_pass
-auth            [success=1 default=ignore]      pam_systemd_home.so
-{% else %}
-auth            [success=1 default=ignore]      pam_unix.so {{ nullok|default('', true) }} {{ debug|default('', true) }} try_first_pass
+auth            [success=2 default=ignore]      pam_systemd_home.so
 {% endif %}
+auth            [success=1 default=ignore]      pam_unix.so {{ nullok|default('', true) }} {{ debug|default('', true) }} try_first_pass
 auth		[default=die]	pam_faillock.so authfail
 
 {% if caps %}


### PR DESCRIPTION
After this change, --homed has this effect:

```diff
--- stack/system-auth   2022-02-12 13:29:54.147933672 -0800
+++ stack.homed/system-auth     2022-02-12 13:29:34.087934022 -0800
@@ -1,10 +1,14 @@
 auth           required        pam_env.so
 auth           requisite       pam_faillock.so preauth
+auth            [success=2 default=ignore]      pam_systemd_home.so
 auth            [success=1 default=ignore]      pam_unix.so   try_first_pass
 auth           [default=die]   pam_faillock.so authfail
+account         [success=1 default=ignore]      pam_systemd_home.so
 account                required        pam_unix.so
 account         required        pam_faillock.so
+password        [success=1 default=ignore]      pam_systemd_home.so
 password        required        pam_unix.so try_first_pass  md5 shadow
 session                required        pam_limits.so
 session                required        pam_env.so
+session         [success=1 default=ignore]      pam_systemd_home.so
 session                required        pam_unix.so
diff -u stack/system-services stack.homed/system-services
--- stack/system-services       2022-02-12 13:29:54.163933671 -0800
+++ stack.homed/system-services 2022-02-12 13:29:34.099934022 -0800
@@ -3,4 +3,5 @@
 session         optional        pam_loginuid.so
 session                required        pam_limits.so
 session                required        pam_env.so
+session         [success=1 default=ignore]      pam_systemd_home.so
 session                required        pam_unix.so
```