### PR TITLE
Honor pam_unix.so return value

### DIFF
--- a/templates/system-auth.tpl
+++ b/templates/system-auth.tpl
@@ -11,7 +11,7 @@ auth		requisite	pam_faillock.so preauth
 {% if homed %}
 auth            [success=2 default=ignore]      pam_systemd_home.so
 {% endif %}
-auth            [success=1 default=ignore]      pam_unix.so {{ nullok|default('', true) }} {{ debug|default('', true) }} try_first_pass
+auth            [success=1 new_authtok_reqd=1 ignore=ignore default=bad]      pam_unix.so {{ nullok|default('', true) }} {{ debug|default('', true) }} try_first_pass
 auth		[default=die]	pam_faillock.so authfail
 
 {% if caps %}

--- a/tests/rendered/custom/system-auth
+++ b/tests/rendered/custom/system-auth
@@ -1,6 +1,6 @@
 auth		required	pam_env.so
 auth		requisite	pam_faillock.so preauth
-auth            [success=1 default=ignore]      pam_unix.so nullok  try_first_pass
+auth            [success=1 new_authtok_reqd=1 ignore=ignore default=bad]      pam_unix.so nullok  try_first_pass
 auth		[default=die]	pam_faillock.so authfail
 account		required	pam_unix.so
 account         required        pam_faillock.so

--- a/tests/rendered/default/system-auth
+++ b/tests/rendered/default/system-auth
@@ -1,6 +1,6 @@
 auth		required	pam_env.so
 auth		requisite	pam_faillock.so preauth
-auth            [success=1 default=ignore]      pam_unix.so   try_first_pass
+auth            [success=1 new_authtok_reqd=1 ignore=ignore default=bad]      pam_unix.so   try_first_pass
 auth		[default=die]	pam_faillock.so authfail
 account		required	pam_unix.so
 account         required        pam_faillock.so

--- a/tests/rendered/minimal/system-auth
+++ b/tests/rendered/minimal/system-auth
@@ -1,6 +1,6 @@
 auth		required	pam_env.so
 auth		requisite	pam_faillock.so preauth
-auth            [success=1 default=ignore]      pam_unix.so   try_first_pass
+auth            [success=1 new_authtok_reqd=1 ignore=ignore default=bad]      pam_unix.so   try_first_pass
 auth		[default=die]	pam_faillock.so authfail
 account		required	pam_unix.so
 account         required        pam_faillock.so


### PR DESCRIPTION
Commit eb138196aa2d3cb860d5eb5ab1d05985df34ad2c changed the return value of `pam_authenticate()` for the case when the user enters an incorrect password.  Prior to that change `pam_authenticate()` would return `PAM_AUTH_ERR` for an incorrect password, while after it would return `PAM_PERM_DENIED`.

The root cause is that after that change, nothing in the stack before the final pam_faillock.so auth entry is setting `impression` in `_pam_dispatch_aux()`.  If the user has not reached the maximum number of tries, pam_faillock.so [returns `PAM_IGNORE`](https://github.com/linux-pam/linux-pam/blob/d3b73b6cd818f4fd9c923822592eccbe8ecdd121/modules/pam_faillock/pam_faillock.c#L712) and thus `_pam_dispatch_aux()` [sets `status` to `PAM_MUST_FAIL_CODE`](https://github.com/linux-pam/linux-pam/blob/d3b73b6cd818f4fd9c923822592eccbe8ecdd121/libpam/pam_dispatch.c#L244), which is [defined to be `PAM_PERM_DENIED`](https://github.com/linux-pam/linux-pam/blob/d3b73b6cd818f4fd9c923822592eccbe8ecdd121/libpam/pam_dispatch.c#L17).  This ends up being the return value for `pam_authenticate()`.

This commit addresses the problem by changing the `default` control action for the pam_unix.so auth entry from `ignore` to `bad` (the same as when its control value was `required`).  Thus when processing the pam_unix.so entry, `_pam_dispatch_aux()` will set `impression` to `_PAM_NEGATIVE` and [`status` to the return value of pam_unix.so, `PAM_AUTH_ERR`](https://github.com/linux-pam/linux-pam/blob/d3b73b6cd818f4fd9c923822592eccbe8ecdd121/libpam/pam_dispatch.c#L246).  `_pam_dispatch_aux()` will then continue to the final pam_faillock.so auth entry.  Because `impression` is now `_PAM_NEGATIVE`, `_pam_dispatch_aux`() will not change the value of `status` and the return value of `pam_authenticate`() is `PAM_AUTH_ERR` as desired.

Also ensure that `new_authtok_reqd` is handled correctly when returned from from pam_unix.so.