### PR TITLE
system-auth: Add support for winbind, like krb5

### DIFF
--- a/templates/system-auth.tpl
+++ b/templates/system-auth.tpl
@@ -1,20 +1,24 @@
 auth		required	pam_env.so {{ debug|default('', true) }}
-
 {% if pam_ssh %}
 auth		sufficient	pam_ssh.so
 {% endif %}
 
 {% if krb5 %}
-auth		[success={{ 4 if homed else 3 }} default=ignore]	pam_krb5.so {{ krb5_params }}
+auth		[success={{ 3 + 1 if homed else 0 + 1 if winbind else 0 }} default=ignore]	pam_krb5.so {{ krb5_params }}
 {% endif %}
 
 auth		requisite	pam_faillock.so preauth
 
 {% if homed %}
-auth		[success=2 default=ignore]	pam_systemd_home.so
+auth		[success={{ 3 if winbind else 2 }} default=ignore]	pam_systemd_home.so
 {% endif %}
 
-auth		[success=1 default=ignore]	pam_unix.so {{ nullok|default('', true) }} {{ debug|default('', true) }} try_first_pass
+auth		[success={{ 2 if winbind else 1 }} default=ignore]	pam_unix.so {{ nullok|default('', true) }} {{ debug|default('', true) }} try_first_pass
+
+{% if winbind %}
+auth		[success=1 default=ignore]	pam_winbind.so use_first_pass {{ debug|default('', true) }}
+{% endif %}
+
 auth		[default=die]	pam_faillock.so authfail
 
 {% if caps %}
@@ -22,14 +26,19 @@ auth		optional	pam_cap.so
 {% endif %}
 
 {% if krb5 %}
-account		[success=2 default=ignore]	pam_krb5.so {{ krb5_params }}
+account		[success={{ 1 + 1 if homed else 0 + 1 if winbind else 0 }} default=ignore]	pam_krb5.so {{ krb5_params }}
 {% endif %}
 
 {% if homed %}
-account		[success=1 default=ignore]	pam_systemd_home.so
+account		[success={{ 2 if winbind else 1 }} default=ignore]	pam_systemd_home.so
+{% endif %}
+
+{% if winbind %}
+account		[success=1 default=ignore]	pam_winbind.so {{ debug|default('', true) }}
 {% endif %}
 
 account		required	pam_unix.so {{ debug|default('', true) }}
+
 account		required	pam_faillock.so
 
 {% if passwdqc %}
@@ -57,6 +66,11 @@ password		required	pam_unix.so try_first_pass {{ unix_authtok|default('', true) 
 {% else %}
 password		required	pam_unix.so try_first_pass {{ nullok|default('', true) }} {{ unix_extended_encryption|default('', true) }} {{ debug|default('', true) }}
 {% endif %}
+
+{% if winbind %}
+password		required	pam_winbind.so {{ unix_authtok|default('', true) }} {{ debug|default('', true) }}
+{% endif %}
+
 
 {% if pam_ssh %}
 session		optional	pam_ssh.so

--- a/templates/system-auth.tpl
+++ b/templates/system-auth.tpl
@@ -1,17 +1,20 @@
 auth		required	pam_env.so {{ debug|default('', true) }}
+
 {% if pam_ssh %}
 auth		sufficient	pam_ssh.so
 {% endif %}
 
 {% if krb5 %}
-auth		[success={{ 4 if homed else 3 }} default=ignore]      pam_krb5.so {{ krb5_params }}
+auth		[success={{ 4 if homed else 3 }} default=ignore]	pam_krb5.so {{ krb5_params }}
 {% endif %}
 
 auth		requisite	pam_faillock.so preauth
+
 {% if homed %}
-auth            [success=2 default=ignore]      pam_systemd_home.so
+auth		[success=2 default=ignore]	pam_systemd_home.so
 {% endif %}
-auth            [success=1 default=ignore]      pam_unix.so {{ nullok|default('', true) }} {{ debug|default('', true) }} try_first_pass
+
+auth		[success=1 default=ignore]	pam_unix.so {{ nullok|default('', true) }} {{ debug|default('', true) }} try_first_pass
 auth		[default=die]	pam_faillock.so authfail
 
 {% if caps %}
@@ -23,36 +26,36 @@ account		[success=2 default=ignore]	pam_krb5.so {{ krb5_params }}
 {% endif %}
 
 {% if homed %}
-account         [success=1 default=ignore]      pam_systemd_home.so
+account		[success=1 default=ignore]	pam_systemd_home.so
 {% endif %}
 
 account		required	pam_unix.so {{ debug|default('', true) }}
-account         required        pam_faillock.so
+account		required	pam_faillock.so
 
 {% if passwdqc %}
-password	required	pam_passwdqc.so config=/etc/security/passwdqc.conf
+password		required	pam_passwdqc.so config=/etc/security/passwdqc.conf
 {% endif %}
 
 {% if pwquality %}
-password        required        pam_pwquality.so
+password		required	pam_pwquality.so
 {% endif %}
 
 {% if pwhistory %}
-password        required        pam_pwhistory.so use_authtok remember=5 retry=3
+password		required	pam_pwhistory.so use_authtok remember=5 retry=3
 {% endif %}
 
 {% if krb5 %}
-password	[success=1 default=ignore]	pam_krb5.so {{ krb5_params }}
+password		[success=1 default=ignore]	pam_krb5.so {{ krb5_params }}
 {% endif %}
 
 {% if homed %}
-password        [success=1 default=ignore]      pam_systemd_home.so
+password		[success=1 default=ignore]	pam_systemd_home.so
 {% endif %}
 
 {% if passwdqc or pwquality %}
-password	required	pam_unix.so try_first_pass {{ unix_authtok|default('', true) }} {{ nullok|default('', true) }} {{ unix_extended_encryption|default('', true) }} {{ debug|default('', true) }}
+password		required	pam_unix.so try_first_pass {{ unix_authtok|default('', true) }} {{ nullok|default('', true) }} {{ unix_extended_encryption|default('', true) }} {{ debug|default('', true) }}
 {% else %}
-password        required        pam_unix.so try_first_pass {{ nullok|default('', true) }} {{ unix_extended_encryption|default('', true) }} {{ debug|default('', true) }}
+password		required	pam_unix.so try_first_pass {{ nullok|default('', true) }} {{ unix_extended_encryption|default('', true) }} {{ debug|default('', true) }}
 {% endif %}
 
 {% if pam_ssh %}


### PR DESCRIPTION
This hasn't been tested, as I am not an expert at pam, or jinja. This PR is intended to serve as an inspiration for how to go about adding winbind support to the system-auth file, in the same way that krb5 or systemd-homed are supported.

I've been using this (Possibly very broken...?) system-auth file for several years on my domain-controller connected linux machines:

and It'd be great if I could stop needing to figure out what's changed everytime pambase is updated.

```
cat /etc/pam.d/system-auth
auth            required                        pam_env.so
auth            requisite                       pam_faillock.so preauth
auth            [success=2 default=ignore]      pam_unix.so nullok try_first_pass
auth            [success=1 default=ignore]      pam_winbind.so use_first_pass
auth            [default=die]                   pam_faillock.so authfail
auth            optional                        pam_permit.so

account         [success=2 default=ignore]      pam_unix.so
account         [success=1 default=ignore]      pam_winbind.so
account         required                        pam_faillock.so
account         optional                        pam_permit.so

password        required                        pam_passwdqc.so config=/etc/security/passwdqc.conf
password        sufficient                      pam_unix.so try_first_pass use_authtok nullok sha512 shadow
password        sufficient                      pam_winbind.so use_authtok
password        optional                        pam_permit.so

session         optional                        pam_systemd.so
session         required                        pam_limits.so
session         required                        pam_env.so
session         required                        pam_unix.so
session         required                        pam_winbind.so
session         optional                        pam_permit.so
```

The way that I wanted my environment to work was to have the system check the local unix auth for success/fail, before attempting to contact the domain controller. I did this because the timeout for winbind can be kind of long, and if i'm trying to log into a local-only-user on a laptop that's not in the domain controllers network, that gets annoying.

That being said, I don't object to seeing winbind contacted first, like systemd-homed and krb5 are in the template file, if that's the direction you want to go.