### PR TITLE
Add basic rendering tests with tox

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git/
+.github/
+stack/
+.dockerignore
+.gitignore
+Dockerfile

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build the Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          load: true
+          tags: pambase
+      - name: Run tox
+        run: docker run pambase

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 stack/
 .idea/
+.tox/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# based on https://github.com/gentoo/gentoo-docker-images
+
+FROM gentoo/portage:latest as portage
+FROM gentoo/stage3:latest
+
+COPY --from=portage /var/db/repos/gentoo /var/db/repos/gentoo
+
+ENV ACCEPT_KEYWORDS="~amd64"
+RUN emerge -qvu python:3.{10..12} dev-python/tox
+
+COPY . /usr/src/pambase
+WORKDIR /usr/src/pambase
+
+CMD tox --colored yes

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# pambase
+
+[PAM](https://wiki.gentoo.org/wiki/PAM) base configuration files.
+
+This repository contains a small [Python](https://wiki.gentoo.org/wiki/Python) script that renders `PAM` configuration templates for [Gentoo Linux](https://www.gentoo.org).
+
+## Dependencies
+
+`pambase` depends on [jinja](https://packages.gentoo.org/packages/dev-python/jinja).
+
+## Testing
+
+In order to perform tests, run [tox](https://packages.gentoo.org/packages/dev-python/tox).
+
+Alternatively, you can run tests with [Docker](https://wiki.gentoo.org/wiki/Docker):
+```sh
+docker run --rm -it $(docker build -q .)
+```

--- a/tests/rendered/custom/login
+++ b/tests/rendered/custom/login
@@ -1,0 +1,5 @@
+auth		include		system-local-login
+account		include		system-local-login
+password	include		system-local-login
+session		optional	pam_lastlog.so
+session		include		system-local-login

--- a/tests/rendered/custom/other
+++ b/tests/rendered/custom/other
@@ -1,0 +1,4 @@
+auth		required	pam_deny.so
+account		required	pam_deny.so
+password		required	pam_deny.so
+session		required	pam_deny.so

--- a/tests/rendered/custom/passwd
+++ b/tests/rendered/custom/passwd
@@ -1,0 +1,4 @@
+auth		sufficient	pam_rootok.so
+auth		include		system-auth
+account		include		system-auth
+password	include		system-auth

--- a/tests/rendered/custom/su
+++ b/tests/rendered/custom/su
@@ -1,0 +1,8 @@
+auth		sufficient	pam_rootok.so
+auth		required	pam_wheel.so use_uid
+auth		include		system-auth
+account		include		system-auth
+password	include		system-auth
+session		include		system-auth
+session		required	pam_env.so
+session		optional	pam_xauth.so

--- a/tests/rendered/custom/system-auth
+++ b/tests/rendered/custom/system-auth
@@ -1,0 +1,11 @@
+auth		required	pam_env.so
+auth		requisite	pam_faillock.so preauth
+auth            [success=1 default=ignore]      pam_unix.so nullok  try_first_pass
+auth		[default=die]	pam_faillock.so authfail
+account		required	pam_unix.so
+account         required        pam_faillock.so
+password	required	pam_passwdqc.so config=/etc/security/passwdqc.conf
+password	required	pam_unix.so try_first_pass use_authtok nullok sha512 shadow
+session		required	pam_limits.so
+session		required	pam_env.so
+session		required	pam_unix.so

--- a/tests/rendered/custom/system-local-login
+++ b/tests/rendered/custom/system-local-login
@@ -1,0 +1,4 @@
+auth		include		system-login
+account		include		system-login
+password	include		system-login
+session		include		system-login

--- a/tests/rendered/custom/system-login
+++ b/tests/rendered/custom/system-login
@@ -1,0 +1,15 @@
+auth		required	pam_shells.so
+auth		required	pam_nologin.so
+auth		include		system-auth
+account		required	pam_access.so
+account		required	pam_nologin.so
+account		required	pam_time.so
+account		include		system-auth
+password	include		system-auth
+session		optional	pam_loginuid.so
+session		required	pam_env.so envfile=/etc/profile.env
+session		optional	pam_lastlog.so silent
+session		include		system-auth
+session		optional	pam_motd.so motd=/etc/motd
+session		optional	pam_mail.so
+-session	optional	pam_elogind.so

--- a/tests/rendered/custom/system-remote-login
+++ b/tests/rendered/custom/system-remote-login
@@ -1,0 +1,4 @@
+auth		include		system-login
+account		include		system-login
+password	include		system-login
+session		include		system-login

--- a/tests/rendered/custom/system-services
+++ b/tests/rendered/custom/system-services
@@ -1,0 +1,6 @@
+auth		sufficient	pam_permit.so
+account		include		system-auth
+session         optional        pam_loginuid.so
+session		required	pam_limits.so
+session		required	pam_env.so
+session		required	pam_unix.so

--- a/tests/rendered/default/login
+++ b/tests/rendered/default/login
@@ -1,0 +1,5 @@
+auth		include		system-local-login
+account		include		system-local-login
+password	include		system-local-login
+session		optional	pam_lastlog.so
+session		include		system-local-login

--- a/tests/rendered/default/other
+++ b/tests/rendered/default/other
@@ -1,0 +1,4 @@
+auth		required	pam_deny.so
+account		required	pam_deny.so
+password		required	pam_deny.so
+session		required	pam_deny.so

--- a/tests/rendered/default/passwd
+++ b/tests/rendered/default/passwd
@@ -1,0 +1,4 @@
+auth		sufficient	pam_rootok.so
+auth		include		system-auth
+account		include		system-auth
+password	include		system-auth

--- a/tests/rendered/default/su
+++ b/tests/rendered/default/su
@@ -1,0 +1,8 @@
+auth		sufficient	pam_rootok.so
+auth		required	pam_wheel.so use_uid
+auth		include		system-auth
+account		include		system-auth
+password	include		system-auth
+session		include		system-auth
+session		required	pam_env.so
+session		optional	pam_xauth.so

--- a/tests/rendered/default/system-auth
+++ b/tests/rendered/default/system-auth
@@ -1,0 +1,10 @@
+auth		required	pam_env.so
+auth		requisite	pam_faillock.so preauth
+auth            [success=1 default=ignore]      pam_unix.so   try_first_pass
+auth		[default=die]	pam_faillock.so authfail
+account		required	pam_unix.so
+account         required        pam_faillock.so
+password        required        pam_unix.so try_first_pass  md5 shadow
+session		required	pam_limits.so
+session		required	pam_env.so
+session		required	pam_unix.so

--- a/tests/rendered/default/system-local-login
+++ b/tests/rendered/default/system-local-login
@@ -1,0 +1,4 @@
+auth		include		system-login
+account		include		system-login
+password	include		system-login
+session		include		system-login

--- a/tests/rendered/default/system-login
+++ b/tests/rendered/default/system-login
@@ -1,0 +1,14 @@
+auth		required	pam_shells.so
+auth		required	pam_nologin.so
+auth		include		system-auth
+account		required	pam_access.so
+account		required	pam_nologin.so
+account		required	pam_time.so
+account		include		system-auth
+password	include		system-auth
+session		optional	pam_loginuid.so
+session		required	pam_env.so envfile=/etc/profile.env
+session		optional	pam_lastlog.so silent
+session		include		system-auth
+session		optional	pam_motd.so motd=/etc/motd
+session		optional	pam_mail.so

--- a/tests/rendered/default/system-remote-login
+++ b/tests/rendered/default/system-remote-login
@@ -1,0 +1,4 @@
+auth		include		system-login
+account		include		system-login
+password	include		system-login
+session		include		system-login

--- a/tests/rendered/default/system-services
+++ b/tests/rendered/default/system-services
@@ -1,0 +1,6 @@
+auth		sufficient	pam_permit.so
+account		include		system-auth
+session         optional        pam_loginuid.so
+session		required	pam_limits.so
+session		required	pam_env.so
+session		required	pam_unix.so

--- a/tests/rendered/minimal/login
+++ b/tests/rendered/minimal/login
@@ -1,0 +1,5 @@
+auth		include		system-local-login
+account		include		system-local-login
+password	include		system-local-login
+session		optional	pam_lastlog.so
+session		include		system-local-login

--- a/tests/rendered/minimal/other
+++ b/tests/rendered/minimal/other
@@ -1,0 +1,4 @@
+auth		required	pam_deny.so
+account		required	pam_deny.so
+password		required	pam_deny.so
+session		required	pam_deny.so

--- a/tests/rendered/minimal/passwd
+++ b/tests/rendered/minimal/passwd
@@ -1,0 +1,4 @@
+auth		sufficient	pam_rootok.so
+auth		include		system-auth
+account		include		system-auth
+password	include		system-auth

--- a/tests/rendered/minimal/su
+++ b/tests/rendered/minimal/su
@@ -1,0 +1,8 @@
+auth		sufficient	pam_rootok.so
+auth		required	pam_wheel.so use_uid
+auth		include		system-auth
+account		include		system-auth
+password	include		system-auth
+session		include		system-auth
+session		required	pam_env.so
+session		optional	pam_xauth.so

--- a/tests/rendered/minimal/system-auth
+++ b/tests/rendered/minimal/system-auth
@@ -1,0 +1,10 @@
+auth		required	pam_env.so
+auth		requisite	pam_faillock.so preauth
+auth            [success=1 default=ignore]      pam_unix.so   try_first_pass
+auth		[default=die]	pam_faillock.so authfail
+account		required	pam_unix.so
+account         required        pam_faillock.so
+password        required        pam_unix.so try_first_pass  md5 shadow
+session		required	pam_limits.so
+session		required	pam_env.so
+session		required	pam_unix.so

--- a/tests/rendered/minimal/system-local-login
+++ b/tests/rendered/minimal/system-local-login
@@ -1,0 +1,4 @@
+auth		include		system-login
+account		include		system-login
+password	include		system-login
+session		include		system-login

--- a/tests/rendered/minimal/system-login
+++ b/tests/rendered/minimal/system-login
@@ -1,0 +1,11 @@
+auth		required	pam_shells.so
+auth		required	pam_nologin.so
+auth		include		system-auth
+account		required	pam_access.so
+account		required	pam_nologin.so
+account		required	pam_time.so
+account		include		system-auth
+password	include		system-auth
+session		optional	pam_loginuid.so
+session		required	pam_env.so envfile=/etc/profile.env
+session		include		system-auth

--- a/tests/rendered/minimal/system-remote-login
+++ b/tests/rendered/minimal/system-remote-login
@@ -1,0 +1,4 @@
+auth		include		system-login
+account		include		system-login
+password	include		system-login
+session		include		system-login

--- a/tests/rendered/minimal/system-services
+++ b/tests/rendered/minimal/system-services
@@ -1,0 +1,6 @@
+auth		sufficient	pam_permit.so
+account		include		system-auth
+session         optional        pam_loginuid.so
+session		required	pam_limits.so
+session		required	pam_env.so
+session		required	pam_unix.so

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,18 @@
+[tox]
+min_version = 4.0
+skipsdist = true
+env_list = py3{10,11,12}-{default,minimal,custom}
+
+[testenv]
+description = check template rendering stability
+deps =
+    jinja2
+allowlist_externals = /usr/bin/diff
+commands =
+    python --version
+    default: python pambase.py
+    default: diff -Nru tests/rendered/default stack
+    minimal: python pambase.py --minimal
+    minimal: diff -Nru tests/rendered/minimal stack
+    custom: python pambase.py --elogind --nullok --passwdqc --sha512
+    custom: diff -Nru tests/rendered/custom stack


### PR DESCRIPTION
Hello,

I believe it would be nice to have at least some basic rendering tests for `pambase`. So here it is :-)
There is a bit related bug: https://bugs.gentoo.org/916869

I realize this is a mirror repository, but I'm not sure if there's a better way to propose these changes.

Best regards!