### PR TITLE
Remove duplicated lastlog module call

### DIFF
--- a/templates/login.tpl
+++ b/templates/login.tpl
@@ -5,5 +5,4 @@ auth		required	pam_securetty.so
 auth		include		system-local-login
 account		include		system-local-login
 password	include		system-local-login
-session		optional	pam_lastlog.so {{ debug|default('', true) }}
 session		include		system-local-login

--- a/tests/rendered/custom/login
+++ b/tests/rendered/custom/login
@@ -1,5 +1,4 @@
 auth		include		system-local-login
 account		include		system-local-login
 password	include		system-local-login
-session		optional	pam_lastlog.so
 session		include		system-local-login

--- a/tests/rendered/default/login
+++ b/tests/rendered/default/login
@@ -1,5 +1,4 @@
 auth		include		system-local-login
 account		include		system-local-login
 password	include		system-local-login
-session		optional	pam_lastlog.so
 session		include		system-local-login

--- a/tests/rendered/minimal/login
+++ b/tests/rendered/minimal/login
@@ -1,5 +1,4 @@
 auth		include		system-local-login
 account		include		system-local-login
 password	include		system-local-login
-session		optional	pam_lastlog.so
 session		include		system-local-login


### PR DESCRIPTION
It displays two entries when authenticating through TTY, the last having the current time so pointless.
Also it is not discarded in minimal configuration.

EDIT:
First introduced in commit ae72ea9e54b7f5035fb6b3120c0e75e79860e819, tag pambase-20140313.
Then imported for rework in commit 405452a4aa5a9ae06169b0aa1c394a4cae9c1c5c.

Closes: https://bugs.gentoo.org/950186

---

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).