### PR TITLE
system-login: display lastlog previous login and put it after MotD, #950228

### DIFF
--- a/templates/system-login.tpl
+++ b/templates/system-login.tpl
@@ -16,9 +16,6 @@ session		required	pam_selinux.so close
 {% endif %}
 
 session		required	pam_env.so envfile=/etc/profile.env {{ debug|default('', true) }}
-{% if not minimal %}
-session		optional	pam_lastlog.so silent {{ debug|default('', true) }}
-{% endif %}
 session		include		system-auth
 {% if selinux %}
  # Note: modules that run in the user's context must come after this line.
@@ -27,9 +24,7 @@ session		required	pam_selinux.so multiple open
 
 {% if not minimal %}
 session		optional	pam_motd.so motd=/etc/motd
-{% endif %}
-
-{% if not minimal %}
+session		optional	pam_lastlog.so silent {{ debug|default('', true) }}
 session		optional	pam_mail.so
 {% endif %}
 

--- a/templates/system-login.tpl
+++ b/templates/system-login.tpl
@@ -24,7 +24,7 @@ session		required	pam_selinux.so multiple open
 
 {% if not minimal %}
 session		optional	pam_motd.so motd=/etc/motd
-session		optional	pam_lastlog.so silent {{ debug|default('', true) }}
+session		optional	pam_lastlog.so never showfailed {{ debug|default('', true) }}
 session		optional	pam_mail.so
 {% endif %}
 

--- a/tests/rendered/custom/system-login
+++ b/tests/rendered/custom/system-login
@@ -8,8 +8,8 @@ account		include		system-auth
 password	include		system-auth
 session		optional	pam_loginuid.so
 session		required	pam_env.so envfile=/etc/profile.env
-session		optional	pam_lastlog.so silent
 session		include		system-auth
 session		optional	pam_motd.so motd=/etc/motd
+session		optional	pam_lastlog.so silent
 session		optional	pam_mail.so
 -session	optional	pam_elogind.so

--- a/tests/rendered/custom/system-login
+++ b/tests/rendered/custom/system-login
@@ -10,6 +10,6 @@ session		optional	pam_loginuid.so
 session		required	pam_env.so envfile=/etc/profile.env
 session		include		system-auth
 session		optional	pam_motd.so motd=/etc/motd
-session		optional	pam_lastlog.so silent
+session		optional	pam_lastlog.so never showfailed
 session		optional	pam_mail.so
 -session	optional	pam_elogind.so

--- a/tests/rendered/default/system-login
+++ b/tests/rendered/default/system-login
@@ -7,7 +7,7 @@ account		include		system-auth
 password	include		system-auth
 session		optional	pam_loginuid.so
 session		required	pam_env.so envfile=/etc/profile.env
-session		optional	pam_lastlog.so silent
 session		include		system-auth
 session		optional	pam_motd.so motd=/etc/motd
+session		optional	pam_lastlog.so silent
 session		optional	pam_mail.so

--- a/tests/rendered/default/system-login
+++ b/tests/rendered/default/system-login
@@ -9,5 +9,5 @@ session		optional	pam_loginuid.so
 session		required	pam_env.so envfile=/etc/profile.env
 session		include		system-auth
 session		optional	pam_motd.so motd=/etc/motd
-session		optional	pam_lastlog.so silent
+session		optional	pam_lastlog.so never showfailed
 session		optional	pam_mail.so


### PR DESCRIPTION
Provide the lastlog information after MotD, the latter can be too big and then eclipse the former, which usually is limited to one or two lines.
Moreover keep displaying the fail attempts while also inform about previous logging.

Closes: https://bugs.gentoo.org/950228

---

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).