### PR TITLE
Rework pam_krb5 auth

### DIFF
--- a/templates/system-auth.tpl
+++ b/templates/system-auth.tpl
@@ -4,7 +4,8 @@ auth		sufficient	pam_ssh.so
 {% endif %}
 
 {% if krb5 %}
-auth		[success={{ 4 if homed else 3 }} default=ignore]	pam_krb5.so {{ debug }} ignore_root try_first_pass
+auth		[success=ok default=1]	pam_krb5.so {{ debug }} ignore_root try_first_pass
+auth		[default={{ 3 + homed + (sssd * 3) }}]	pam_permit.so
 {% endif %}
 
 {% if sssd %}


### PR DESCRIPTION
If pam_krb5 succeeds, set the action to ok and use a dummy pam_permit to skip over the other auth modules.

This should fix breakage triggered by removing pam_shells by default.

Bug: https://bugs.gentoo.org/939892
Bug: https://bugs.gentoo.org/956600